### PR TITLE
URL Cleanup

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -7,7 +7,7 @@ Stephane Maldini, Ben Hale, Madhura Bhave - Pivotal
 :spring-boot-version: 2.1.1.RELEASE
 :spring-framework-version: 5.1.3.RELEASE
 :reactor-version: CALIFORNIUM-SR3
-:spring-framework-doc-base: http://docs.spring.io/spring-framework/docs/{spring-framework-version}
+:spring-framework-doc-base: https://docs.spring.io/spring-framework/docs/{spring-framework-version}
 
 This repository hosts a complete workshop on Spring + Reactor.
 Just follow this README and create your first reactive Spring applications!
@@ -21,7 +21,7 @@ At the end of the workshop, we will have created three applications:
 
 Reference documentations can be useful while working on those apps:
 
-* http://projectreactor.io/docs[Reactor Core documentation]
+* https://projectreactor.io/docs[Reactor Core documentation]
 * https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html[API documentation for Flux]
 * https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html[API documentation for Mono]
 * Spring WebFlux

--- a/scripts/grafana-datasource.yml
+++ b/scripts/grafana-datasource.yml
@@ -4,4 +4,4 @@ datasources:
 - name: prometheus
   type: prometheus
   access: direct
-  url: http://10.200.10.1:9090
+  url: https://10.200.10.1:9090

--- a/scripts/grafana-datasource.yml
+++ b/scripts/grafana-datasource.yml
@@ -4,4 +4,6 @@ datasources:
 - name: prometheus
   type: prometheus
   access: direct
-  url: https://10.200.10.1:9090
+# Note Prometheus should preferably be secured by a reverse proxy
+# See https://prometheus.io/docs/operating/security/#authentication-authorization-and-encryption
+  url: http://10.200.10.1:9090


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://10.200.10.1:9090 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://10.200.10.1:9090 ([https](https://10.200.10.1:9090) result ConnectTimeoutException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-framework/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-framework/docs/ ([https](https://docs.spring.io/spring-framework/docs/) result 200).
* [ ] http://projectreactor.io/docs with 1 occurrences migrated to:  
  https://projectreactor.io/docs ([https](https://projectreactor.io/docs) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/details with 1 occurrences
* http://localhost:8080/details/MSFT with 1 occurrences
* http://localhost:8080/details/PIZZA with 1 occurrences
* http://localhost:8080/quotes/feed with 1 occurrences
* http://localhost:8080/quotes/summary/MSFT with 1 occurrences
* http://localhost:8080/quotes/summary/PIZZA with 1 occurrences
* http://localhost:8081/quotes with 2 occurrences
* http://localhost:8082/details with 1 occurrences
* http://localhost:8082/details/ with 1 occurrences