### PR TITLE
URL Cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -813,7 +813,7 @@ Each step of this workshop has its companion commit in the git history with a de
 <div class="ulist">
 <ul>
 <li>
-<p><a href="http://projectreactor.io/docs">Reactor Core documentation</a></p>
+<p><a href="https://projectreactor.io/docs">Reactor Core documentation</a></p>
 </li>
 <li>
 <p><a href="https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html">API documentation for Flux</a></p>
@@ -823,8 +823,8 @@ Each step of this workshop has its companion commit in the git history with a de
 </li>
 <li>
 <p>Spring WebFlux
-<a href="http://docs.spring.io/spring-framework/docs/5.0.4.RELEASE/spring-framework-reference/web.html#web-reactive">reference documentation</a>
-and <a href="http://docs.spring.io/spring-framework/docs/5.0.4.RELEASE/javadoc-api/">javadoc</a></p>
+<a href="https://docs.spring.io/spring-framework/docs/5.0.4.RELEASE/spring-framework-reference/web.html#web-reactive">reference documentation</a>
+and <a href="https://docs.spring.io/spring-framework/docs/5.0.4.RELEASE/javadoc-api/">javadoc</a></p>
 </li>
 </ul>
 </div>
@@ -1530,7 +1530,7 @@ annotation in <code>@Controller</code> classes.</p>
 </div>
 <div class="paragraph">
 <p>Take a look at the code samples in
-<a href="http://docs.spring.io/spring-framework/docs/5.0.4.RELEASE/spring-framework-reference/web.html#web-reactive-server-functional">the Spring WebFlux.fn reference documentation</a></p>
+<a href="https://docs.spring.io/spring-framework/docs/5.0.4.RELEASE/spring-framework-reference/web.html#web-reactive-server-functional">the Spring WebFlux.fn reference documentation</a></p>
 </div>
 </div>
 <div class="sect2">


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [x] http://docs.spring.io/spring-framework/docs/5.0.4.RELEASE/javadoc-api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-framework/docs/5.0.4.RELEASE/javadoc-api/ ([https](https://docs.spring.io/spring-framework/docs/5.0.4.RELEASE/javadoc-api/) result 200).
* [x] http://docs.spring.io/spring-framework/docs/5.0.4.RELEASE/spring-framework-reference/web.html with 2 occurrences migrated to:  
  https://docs.spring.io/spring-framework/docs/5.0.4.RELEASE/spring-framework-reference/web.html ([https](https://docs.spring.io/spring-framework/docs/5.0.4.RELEASE/spring-framework-reference/web.html) result 200).
* [x] http://projectreactor.io/docs with 1 occurrences migrated to:  
  https://projectreactor.io/docs ([https](https://projectreactor.io/docs) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/details with 2 occurrences
* http://localhost:8080/details/MSFT with 2 occurrences
* http://localhost:8080/details/PIZZA with 2 occurrences
* http://localhost:8080/quotes/feed with 2 occurrences
* http://localhost:8080/quotes/summary/MSFT with 2 occurrences
* http://localhost:8080/quotes/summary/PIZZA with 2 occurrences
* http://localhost:8081/quotes with 1 occurrences