### PR TITLE
URL Cleanup

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -6,7 +6,7 @@ Brian Clozel, Violeta Georgieva - Pivotal
 :toc: 
 :spring-boot-version: 2.0.0.M1
 :spring-framework-version: 5.0.0.RC1
-:spring-framework-doc-base: http://docs.spring.io/spring-framework/docs/{spring-framework-version}
+:spring-framework-doc-base: https://docs.spring.io/spring-framework/docs/{spring-framework-version}
 
 This repository hosts a complete workshop on Spring Boot + Spring WebFlux.
 Just follow this README and create your first WebFlux applications!
@@ -19,7 +19,7 @@ We'll create two applications:
 
 Reference documentations can be useful while working on those apps:
 
-* http://projectreactor.io/docs[Reactor Core documentation]
+* https://projectreactor.io/docs[Reactor Core documentation]
 * Spring WebFlux 
 {spring-framework-doc-base}/spring-framework-reference/web.html#web-reactive[reference documentation]
 and {spring-framework-doc-base}/javadoc-api/[javadoc]

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
 <title>Spring WebFlux Workshop</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -481,12 +481,12 @@ Each step of this workshop has its companion commit in the git history with a de
 <div class="ulist">
 <ul>
 <li>
-<p><a href="http://projectreactor.io/docs">Reactor Core documentation</a></p>
+<p><a href="https://projectreactor.io/docs">Reactor Core documentation</a></p>
 </li>
 <li>
 <p>Spring WebFlux
-<a href="http://docs.spring.io/spring-framework/docs/5.0.0.RC1/spring-framework-reference/web.html#web-reactive">reference documentation</a>
-and <a href="http://docs.spring.io/spring-framework/docs/5.0.0.RC1/javadoc-api/">javadoc</a></p>
+<a href="https://docs.spring.io/spring-framework/docs/5.0.0.RC1/spring-framework-reference/web.html#web-reactive">reference documentation</a>
+and <a href="https://docs.spring.io/spring-framework/docs/5.0.0.RC1/javadoc-api/">javadoc</a></p>
 </li>
 </ul>
 </div>
@@ -722,7 +722,7 @@ annotation in <code>@Controller</code> classes.</p>
 </div>
 <div class="paragraph">
 <p>Take a look at the code samples in
-<a href="http://docs.spring.io/spring-framework/docs/5.0.0.RC1/spring-framework-reference/web.html#web-reactive-server-functional">the Spring WebFlux.fn reference documentation</a></p>
+<a href="https://docs.spring.io/spring-framework/docs/5.0.0.RC1/spring-framework-reference/web.html#web-reactive-server-functional">the Spring WebFlux.fn reference documentation</a></p>
 </div>
 </div>
 <div class="sect2">
@@ -1162,7 +1162,7 @@ public class UserControllerTests {
 <div class="title">trading-service/src/main/resources/templates/index.html</div>
 <div class="content">
 <pre class="prettyprint highlight"><code class="language-html" data-lang="html">&lt;!DOCTYPE html&gt;
-&lt;html lang="en" xmlns:th="http://www.thymeleaf.org"&gt;
+&lt;html lang="en" xmlns:th="https://www.thymeleaf.org"&gt;
 &lt;head&gt;
     &lt;meta charset="utf-8"/&gt;
     &lt;meta http-equiv="X-UA-Compatible" content="IE=edge"/&gt;
@@ -1268,7 +1268,7 @@ there&#8217;s no need to involve blocking code at all!
 <div class="title">trading-service/src/main/resources/templates/quotes.html</div>
 <div class="content">
 <pre class="prettyprint highlight"><code class="language-html" data-lang="html">&lt;!DOCTYPE html&gt;
-&lt;html lang="en" xmlns:th="http://www.thymeleaf.org"&gt;
+&lt;html lang="en" xmlns:th="https://www.thymeleaf.org"&gt;
 &lt;head&gt;
     &lt;meta charset="utf-8"/&gt;
     &lt;meta http-equiv="X-UA-Compatible" content="IE=edge"/&gt;
@@ -1402,7 +1402,7 @@ to handle WebSocket session.</p>
 </div>
 <div class="paragraph">
 <p>Take a look at the code samples in
-<a href="http://docs.spring.io/spring-framework/docs/5.0.0.RC1/spring-framework-reference/web.html#web-reactive-websocket-support">Reactive WebSocket Support documentation</a></p>
+<a href="https://docs.spring.io/spring-framework/docs/5.0.0.RC1/spring-framework-reference/web.html#web-reactive-websocket-support">Reactive WebSocket Support documentation</a></p>
 </div>
 <div class="paragraph">
 <p>First, create an <code>EchoWebSocketHandler</code> class; it has to implement <code>WebSocketHandler</code>.
@@ -1425,7 +1425,7 @@ the incoming request to the default <code>WebSocketService</code> which is <code
 <div class="title">trading-service/src/main/resources/templates/websocket.html</div>
 <div class="content">
 <pre class="prettyprint highlight"><code class="language-html" data-lang="html">&lt;!DOCTYPE html&gt;
-&lt;html lang="en" xmlns:th="http://www.thymeleaf.org"&gt;
+&lt;html lang="en" xmlns:th="https://www.thymeleaf.org"&gt;
 &lt;head&gt;
     &lt;meta charset="utf-8"/&gt;
     &lt;meta http-equiv="X-UA-Compatible" content="IE=edge"/&gt;


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [x] http://asciidoctor.org with 1 occurrences migrated to:  
  https://asciidoctor.org ([https](https://asciidoctor.org) result 200).
* [x] http://docs.spring.io/spring-framework/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-framework/docs/ ([https](https://docs.spring.io/spring-framework/docs/) result 200).
* [x] http://docs.spring.io/spring-framework/docs/5.0.0.RC1/javadoc-api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-framework/docs/5.0.0.RC1/javadoc-api/ ([https](https://docs.spring.io/spring-framework/docs/5.0.0.RC1/javadoc-api/) result 200).
* [x] http://docs.spring.io/spring-framework/docs/5.0.0.RC1/spring-framework-reference/web.html with 3 occurrences migrated to:  
  https://docs.spring.io/spring-framework/docs/5.0.0.RC1/spring-framework-reference/web.html ([https](https://docs.spring.io/spring-framework/docs/5.0.0.RC1/spring-framework-reference/web.html) result 200).
* [x] http://projectreactor.io/docs with 2 occurrences migrated to:  
  https://projectreactor.io/docs ([https](https://projectreactor.io/docs) result 200).
* [x] http://www.thymeleaf.org with 3 occurrences migrated to:  
  https://www.thymeleaf.org ([https](https://www.thymeleaf.org) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8081/echo with 2 occurrences
* http://localhost:8081/hello with 2 occurrences
* http://localhost:8081/quotes with 4 occurrences
* http://localhost:8081/quotes?take=7 with 2 occurrences
* http://localhost:8082/details/ with 2 occurrences