### PR TITLE
URL Cleanup

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -7,7 +7,7 @@ Stephane Maldini, Ben Hale, Madhura Bhave - Pivotal
 :spring-boot-version: 2.0.4.RELEASE
 :spring-framework-version: 5.0.8.RELEASE
 :reactor-version: BISMUTH-SR10
-:spring-framework-doc-base: http://docs.spring.io/spring-framework/docs/{spring-framework-version}
+:spring-framework-doc-base: https://docs.spring.io/spring-framework/docs/{spring-framework-version}
 
 This repository hosts a complete workshop on Spring + Reactor.
 Just follow this README and create your first reactive Spring applications!
@@ -21,7 +21,7 @@ At the end of the workshop, we will have created three applications:
 
 Reference documentations can be useful while working on those apps:
 
-* http://projectreactor.io/docs[Reactor Core documentation]
+* https://projectreactor.io/docs[Reactor Core documentation]
 * https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html[API documentation for Flux]
 * https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html[API documentation for Mono]
 * Spring WebFlux


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [x] http://docs.spring.io/spring-framework/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-framework/docs/ ([https](https://docs.spring.io/spring-framework/docs/) result 200).
* [x] http://projectreactor.io/docs with 1 occurrences migrated to:  
  https://projectreactor.io/docs ([https](https://projectreactor.io/docs) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/details with 1 occurrences
* http://localhost:8080/details/MSFT with 1 occurrences
* http://localhost:8080/details/PIZZA with 1 occurrences
* http://localhost:8080/quotes/feed with 1 occurrences
* http://localhost:8080/quotes/summary/MSFT with 1 occurrences
* http://localhost:8080/quotes/summary/PIZZA with 1 occurrences
* http://localhost:8081/quotes with 1 occurrences